### PR TITLE
Refactors paths in tests to use path helpers instead

### DIFF
--- a/spec/features/books/book_show_spec.rb
+++ b/spec/features/books/book_show_spec.rb
@@ -11,7 +11,7 @@ describe 'when I visit /books/:id' do
       BookAuthor.create(author: herman_melville, book: book_1)
       BookAuthor.create(author: stephen_king, book: book_2)
 
-      visit "/books/#{book_1.id}"
+      visit book_path(book_1)
 
       expect(page).to have_content(book_1.title)
       expect(page).to have_content(book_1.authors.pluck(:name).join("\n"))

--- a/spec/features/books/index_spec.rb
+++ b/spec/features/books/index_spec.rb
@@ -9,7 +9,7 @@ describe 'when I visit /books' do
       BookAuthor.create(author: stephen_king, book: book_1)
       BookAuthor.create(author: stephen_king, book: book_2)
 
-      visit '/books'
+      visit books_path
 
       within "#book-#{book_1.id}" do
 
@@ -41,7 +41,7 @@ describe 'when I visit /books' do
       BookAuthor.create(author: stephen_king, book: book_2)
       BookAuthor.create(author: herman_melville, book: book_2)
 
-      visit '/books'
+      visit books_path
 
       within "#book-#{book_2.id}" do
 


### PR DESCRIPTION
Modifies feature tests to use path helpers. No forms have been implemented at current point, so refactoring of forms to use form_helper is not required.